### PR TITLE
Read json output instead of stdout

### DIFF
--- a/coursera_autograder/commands/grade.py
+++ b/coursera_autograder/commands/grade.py
@@ -83,8 +83,9 @@ def run_container(docker, container, args):
         stdout_output = stdout_output.decode("utf-8")
     error_in_grader_output = False
     try:
-        json_out = stdout_output.split("\n")
-        parsed_output = json.loads(json_out[-2] if json_out[-1] == "" else json_out[-1])
+        json_file = open(path.join(args.dist_dir, 'feedback.json'), 'r')
+        parsed_output = json.loads(jsonFile)
+        json_file.close()
     except ValueError:
         logging.error("The output was not a valid JSON document.")
         error_in_grader_output = True

--- a/coursera_autograder/commands/grade.py
+++ b/coursera_autograder/commands/grade.py
@@ -83,8 +83,8 @@ def run_container(docker, container, args):
         stdout_output = stdout_output.decode("utf-8")
     error_in_grader_output = False
     try:
-        json_file = open(path.join(args.dist_dir, 'feedback.json'), 'r')
-        parsed_output = json.loads(jsonFile)
+        json_file = open(path.join(args.dst_dir, 'feedback.json'), 'r')
+        parsed_output = json.loads(json_file)
         json_file.close()
     except ValueError:
         logging.error("The output was not a valid JSON document.")

--- a/coursera_autograder/commands/grade.py
+++ b/coursera_autograder/commands/grade.py
@@ -84,7 +84,7 @@ def run_container(docker, container, args):
     error_in_grader_output = False
     try:
         json_file = open(path.join(args.dst_dir, 'feedback.json'), 'r')
-        parsed_output = json.loads(json_file)
+        parsed_output = json.load(json_file)
         json_file.close()
     except ValueError:
         logging.error("The output was not a valid JSON document.")


### PR DESCRIPTION
This PR proposes a way to read the feedback.json file rather than stdout when using `grade local`.
This would make integration tests relying on `grade local` more coherent with the new API which expects output files.