### PR TITLE
Custom command line arguments parsing/setup fix

### DIFF
--- a/coursera_autograder/commands/grade.py
+++ b/coursera_autograder/commands/grade.py
@@ -243,4 +243,8 @@ def parser(subparsers):
     parser_grade_local.add_argument(
         'envVar',
         help='Environment variable that passed into the container')
+    parser_grade_local.add_argument(
+        'args',
+        nargs=argparse.REMAINDER,
+        help='Arguments to the docker executable')
     return parser_grade


### PR DESCRIPTION
Problem: our grader for our courses is a custom one. It uses custom command line agruments and previous courseraprogramming library support this.

After transitioning to new coursera_autograder library custom command line arguments raise command line arguments error.
I check old courseraprogramming implementation. It seems, like python argparse-based parser pack all cursom arguments at line <221> to list and use them at line <153> of file <grade.py>.
New coursera_autograder missing this list parsing. Instead of it, it parse envVar argument. But envVar one is not the one, which provide custom command line arguments support (it has another purposes).
Moreover, is seems like an issue (maybe merge issues or something like that) and not like a feature, because code, which one depend of list parsing is still available at coursera_autograder's <grade.py> at line <169>

So... i create this pull request :)