### PR TITLE
Enable configure command

### DIFF
--- a/coursera_autograder/commands/__init__.py
+++ b/coursera_autograder/commands/__init__.py
@@ -2,7 +2,8 @@
 
 __all__ = [
     "upload",
-    "grade"
+    "grade",
+    "config"
 ]
 
 from . import *  # noqa

--- a/coursera_autograder/commands/config.py
+++ b/coursera_autograder/commands/config.py
@@ -20,7 +20,7 @@ Coursera's asynchronous grader command line SDK.
 You may install it from source, or via pip.
 """
 
-from courseraprogramming.commands import oauth2
+from coursera_autograder.commands import oauth2
 import requests
 import logging
 import time
@@ -29,7 +29,7 @@ import sys
 
 def check_auth(args):
     """
-    Checks courseraprogramming's connectivity to the coursera.org API servers
+    Checks coursera_autograder's connectivity to the coursera.org API servers
     """
     oauth2_instance = oauth2.build_oauth2(args)
     auth = oauth2_instance.build_authorizer()

--- a/coursera_autograder/main.py
+++ b/coursera_autograder/main.py
@@ -56,7 +56,7 @@ def build_parser():
     # commands.cat.parser(subparsers)
 
     # create the parser for the configure subcommand. (authentication / etc.)
-    # commands.config.parser(subparsers)
+    commands.config.parser(subparsers)
 
     # create the parser for the grade subcommand.
     commands.grade.parser(subparsers)


### PR DESCRIPTION
Enabled the `coursera_autograder configure` command. Tested it by running it with the two options (check-auth and display-auth-cache) and verifying that the outputs matched up.