### PR TITLE
Add resource limit command

### DIFF
--- a/coursera_autograder/commands/__init__.py
+++ b/coursera_autograder/commands/__init__.py
@@ -2,7 +2,8 @@
 
 __all__ = [
     "upload",
-    "grade"
+    "grade",
+    "resources"
 ]
 
 from . import *  # noqa

--- a/coursera_autograder/commands/__init__.py
+++ b/coursera_autograder/commands/__init__.py
@@ -3,7 +3,7 @@
 __all__ = [
     "upload",
     "grade",
-    "resources"
+    "resources",
     "config"
 ]
 

--- a/coursera_autograder/commands/__init__.py
+++ b/coursera_autograder/commands/__init__.py
@@ -3,11 +3,8 @@
 __all__ = [
     "upload",
     "grade",
-<<<<<<< HEAD
     "resources"
-=======
     "config"
->>>>>>> c023672fdd841bfeed512fb08e68289494fa0e39
 ]
 
 from . import *  # noqa

--- a/coursera_autograder/commands/resources.py
+++ b/coursera_autograder/commands/resources.py
@@ -44,8 +44,6 @@ def command_resources(args):
     course_branch_id = args.course.replace("~", "!~") if "authoringBranch" in args.course else args.course
     course_branch_item = '%s~%s' % (course_branch_id, args.item)
 
-    s.cookies.update({'ASG_PREFERENCE': '_VC5f2YRcjU7fHfPqB50Rrm28PLNtlnCQzx7MwMCH_6IaIhDGMc-r60p5ZRM2_sAi2yg4ZNAgs-9woRrluj2tw.4-KlTmrD1EWB_e2l8z6s1Q.WE24gP_rf77oztF1N3kO0rUjY9gnNa0ftqEazenTV3AqNQy1NeXbyWMaIUt24p_BEx0j8oGOJwXW22CL_2XOzRfqt8BeyTrUmIYFSm2_UhhjcbzRTuCx3xsb19wTJAQ9KCu2oReljTZpGADhv5XZpg'})
-
     params = 'id=%s&partId=%s' % (course_branch_item, args.item)
     result = s.post(args.executorInfo_endpoint, params=params)
     print('Reserved CPU (MB):', result.json()['reservedCpu'])

--- a/coursera_autograder/commands/resources.py
+++ b/coursera_autograder/commands/resources.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+# Copyright 2015 Coursera
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Coursera's asynchronous grader command line SDK.
+
+You may install it from source, or via pip.
+"""
+
+from coursera_autograder.commands import common
+from coursera_autograder.commands import oauth2
+import requests
+import urllib.parse
+
+"""
+target fields:
+  reservedCpu: int?
+  reservedMemory: int?
+  wallClockTimeout: int?
+"""
+
+def command_resources(args):
+    "Implements the resources subcommand"
+
+    oauth2_instance = oauth2.build_oauth2(args)
+    auth = oauth2_instance.build_authorizer()
+
+    s = requests.Session()
+    s.auth = auth
+
+    course_branch_id = args.course.replace("~", "!~") if "authoringBranch" in args.course else args.course
+    course_branch_item = '%s~%s' % (course_branch_id, args.item)
+
+    s.cookies.update({'ASG_PREFERENCE': '_VC5f2YRcjU7fHfPqB50Rrm28PLNtlnCQzx7MwMCH_6IaIhDGMc-r60p5ZRM2_sAi2yg4ZNAgs-9woRrluj2tw.4-KlTmrD1EWB_e2l8z6s1Q.WE24gP_rf77oztF1N3kO0rUjY9gnNa0ftqEazenTV3AqNQy1NeXbyWMaIUt24p_BEx0j8oGOJwXW22CL_2XOzRfqt8BeyTrUmIYFSm2_UhhjcbzRTuCx3xsb19wTJAQ9KCu2oReljTZpGADhv5XZpg'})
+
+    params = 'id=%s&partId=%s' % (course_branch_item, args.item)
+    result = s.post(args.executorInfo_endpoint, params=params)
+    print('Reserved CPU (MB):', result.json()['reservedCpu'])
+    print('Reserved Memory (MB):', result.json()['reservedMemory'])
+    print('Wall Clock Timeout:', result.json()['wallClockTimeout'] if 'wallClockTimeout' in result.json() else 'Timeout not set - default is 1200 seconds')
+
+
+def setup_registration_parser(parser): 
+    'This is a helper function to coalesce all the common registration'
+    'parameters for code reuse.'
+
+    parser.add_argument(
+        'course',
+        help='The course id to associate the grader. The course id is a '
+        'gibberish string UUID. Given a course slug such as `developer-iot`, '
+        'you can retrieve the course id by querying the catalog API. e.g.: '
+        'https://api.coursera.org/api/onDemandCourses.v1?q=slug&'
+        'slug=developer-iot')
+
+    parser.add_argument(
+        'item',
+        help='The id of the item to associate the grader. The easiest way '
+        'to find the item id is by looking at the URL in the authoring web '
+        'interface. It is the last part of the URL, and is a short UUID.')
+
+    parser.add_argument(
+        'part',
+        help='The id of the part to associate the grader.')
+
+    parser.add_argument(
+        '--executorInfo-endpoint',
+        default='https://api.coursera.org/api/authoringProgrammingAssignments.v3/?action=getExecutorResources',
+        help='Override the endpoint used to retrieve information about a certain executor'
+    )
+
+
+
+def parser(subparsers):
+    "Build an argparse argument parser to parse the command line."
+
+    # create the parser for the resources command
+    parser_resources = subparsers.add_parser(
+        'resources',
+        help='Gets the current resource limits of a programming assignment \
+            part (autograder).')
+    parser_resources.set_defaults(func=command_resources)
+
+    setup_registration_parser(parser_resources)
+
+    return parser_resources

--- a/coursera_autograder/commands/resources.py
+++ b/coursera_autograder/commands/resources.py
@@ -74,8 +74,8 @@ def command_resources(args):
         return 1
     print(
         '\nResource Limits for executor with part id %s in item %s in course %s:\n'
-        'Reserved CPU (AWS units -- 1024 units = 1 vCPU): %s (%s)\n'
-        'Reserved Memory (MB): %s\n'
+        'Reserved CPU (AWS units -- 1024 units = 1 vCPU): %s (%s vCPUs)\n'
+        'Reserved Memory (MiB): %s\n'
         'Wall Clock Timeout (s): %s\n' %
         (args.part,
          args.item,

--- a/coursera_autograder/commands/resources.py
+++ b/coursera_autograder/commands/resources.py
@@ -42,8 +42,6 @@ def command_resources(args):
     s = requests.Session()
     s.auth = auth
 
-    s.cookies.update({'ASG_PREFERENCE': 'WyqA7Q34defdrIXh2OfAx4-7TrxkU_-fStuPfq2X2fVKFKrFCRqPQ7PrJwFb4TPsfePh3Qq2RN6IhkmK94kb7g.HxAFeo56tn7jnBRxAINOUg.2CN6rem2V12w6GZ46fjxnvu9v_gbSNH7z_tclQyDG3pAGHy24oaBgoqCtcEuHiU4FIemi88AagAVcWvfGvABWjZMEJyBrZmmN4VCfdJUKfOI-8BGu1RxhdgqqEJkAWnHyGbWj0-N28a9NTYR3p2F8sM_rnDx5mowB6Gd593wQrox9QRgqu9ToOg2ny0_lOAhG5BLBmZcgrXpz0DcWSbtrQ'})
-
     course_branch_id = args.course.replace("~", "!~") if "authoringBranch" in args.course else args.course
     course_branch_item = '%s~%s' % (course_branch_id, args.item)
 

--- a/coursera_autograder/main.py
+++ b/coursera_autograder/main.py
@@ -86,6 +86,9 @@ def build_parser():
     # create the parser for the reregister command.
     # commands.reregister.parser(subparsers)
 
+    # create the parser for the current-resources command.
+    commands.resources.parser(subparsers)
+
     return parser
 
 


### PR DESCRIPTION
### Summary
Adding the `resource` command to coursera_autograder SDK. This gets information about resource limits for a specific executor. So far, the base functionality seems to be working, but I still need to do testing on other use cases to make sure that we can fail gracefully in those scenarios.

### Test Plan
Tested using commands following the form:
```
coursera_autograder get_resource_limits <courseId> <itemId> <partId>
```

#### Cases tested:

**Valid course/item/part ids (should print out message describing resource limits)**
Input:
```
coursera_autograder get_resource_limits authoringBranch~nJc-PcxXEeqDJgprEGyUfw 3yCXe IjTas
```
Output: 
```
Resource Limits for executor with part id q5F9W in item dx1Mn in course authoringBranch~nJc-PcxXEeqDJgprEGyUfw:
Reserved CPU (AWS units -- 1024 units = 1 vCPU): 1024 (1.0 vCPUs)
Reserved Memory (MiB): 4096
Wall Clock Timeout (s): Timeout not set - default is 1200 seconds
```

**Valid course/item/part ids with non-default limits**
Input:
```
coursera_autograder get_resource_limits authoringBranch~nJc-PcxXEeqDJgprEGyUfw dx1Mn q5F9W
```
Output:
```
Resource Limits for executor with part id IjTas in item 3yCXe in course authoringBranch~nJc-PcxXEeqDJgprEGyUfw:
Reserved CPU (AWS units -- 1024 units = 1 vCPU): 2048 (2.0 vCPUs)
Reserved Memory (MiB): 3072
Wall Clock Timeout (s): 1400
```

**Invalid part id (should throw 400 bad request error)**
Input:
```
coursera_autograder get_resource_limits authoringBranch~nJc-PcxXEeqDJgprEGyUfw dx1Mn q5F9
```

Output: 
```
ERROR:root:
Unable to get executor resources.
CourseId: authoringBranch~nJc-PcxXEeqDJgprEGyUfw
ItemId: dx1Mn
PartId: q5F9
Status Code: 400
URL: https://api.coursera.org/api/authoringProgrammingAssignments.v3/?action=getGraderResourceLimits&id=authoringBranch!~nJc-PcxXEeqDJgprEGyUfw~dx1Mn&partId=q5F9
Response: {"errorCode":"MultipartPartId(q5F9) does not exist","message":null,"details":null}
```