### PR TITLE
update README, unit tests, and error messaging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,15 +96,14 @@ file within that directory contains a refresh token for the user who authorized
 themselves. This refresh token should be treated as if it were a password and
 not shared or otherwise disclosed!
 
-To find the course id, item id, and part id, first go to the web authoring
+To find the course branch id, item id, and part id, first go to the web authoring
 interface for your programming assignment. There, the URL will be of the form:
-``/:courseSlug/author/outline/programming/:itemId/``. The part id will be
-displayed in the authoring user interface for each part. To convert the
-``courseSlug`` into a ``courseId``, you can take advantage of our `Course API` putting in the appropriate ``courseSlug``. For example, given a
-course slug of ``developer-iot``, you can query the course id by making the
-request: ``https://api.coursera.org/api/onDemandCourses.v1?q=slug&slug=developer-iot``.
-The response will be a JSON object containing an ``id`` field with the value:
-``iRl53_BWEeW4_wr--Yv6Aw``.
+``/teach/:courseSlug/:courseBranchId/content/edit/programming/:itemId/``. The part id will be
+displayed in the authoring user interface for each part. 
+
+Note: if your coursera_autograder version is earlier than v0.2.0 and your course branch id has 
+the form `authoringBranch!~id`, make sure to remove the exclamation mark (!) preceding the tilde (~). 
+This is fixed in v0.2.0 and later releases.
 
 The uploaded grader can be linked to multiple (itemId, partId) pairs without making duplicate uploads by using the ``--additional_item_and_part`` flag.
 
@@ -153,7 +152,7 @@ get_resource_limits
 ^^^^^^^^^^^^^^^^^^^
 
 Allows an instructional team to view the resource limits (vCPU's, MiB, timeout) allocated to the grader for a given programming assignment.
-It requires the instructor to provide the course id, item id, and part id to identify the specific programming assignment. Instructions on 
+It requires the instructor to provide the course branch id, item id, and part id to identify the specific programming assignment. Instructions on 
 how to find these values can be found in the previous section for the ``upload`` command.
 
 Usage:
@@ -163,7 +162,7 @@ update_resource_limits
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Allows an instructional team to update the resource limits (vCPU's, MiB, timeout) allocated to the grader for a given programming assignment.
-It requires the instructor to provide the course id, item id, and part id to identify the specific programming assignment. Instructions on 
+It requires the instructor to provide the course branch id, item id, and part id to identify the specific programming assignment. Instructions on 
 how to find these values can be found in the previous section for the ``upload`` command. In addition, the instructor must provide the values
 they wish to update by using the parameter flags
 

--- a/coursera_autograder/commands/config.py
+++ b/coursera_autograder/commands/config.py
@@ -116,4 +116,8 @@ def parser(subparsers):
         action='store_true',
         help='Do not truncate the keys [DANGER!!]')
 
+    if len(sys.argv) == 2 and sys.argv[1] == 'configure':
+        parser_config.print_help(sys.stderr)
+        sys.exit(1)
+
     return parser_config

--- a/tests/commands/config_tests.py
+++ b/tests/commands/config_tests.py
@@ -32,6 +32,7 @@ def test_config_parsing_check_auth():
     args = parser.parse_args('configure display-auth-cache'.split())
     assert args.func == config.display_auth_cache
 
+
 @patch('coursera_autograder.commands.config.sys.exit')
 def test_config_help_message(exit):
     testargs = ['placeholder', 'configure']
@@ -39,4 +40,4 @@ def test_config_help_message(exit):
         with patch.object(sys, 'argv', testargs):
             parser = main.build_parser()
 
-    config.sys.exit.assert_called_with(1) 
+    config.sys.exit.assert_called_with(1)

--- a/tests/commands/config_tests.py
+++ b/tests/commands/config_tests.py
@@ -16,6 +16,9 @@
 
 from coursera_autograder import main
 from coursera_autograder.commands import config
+from testfixtures import LogCapture
+import sys
+from mock import patch
 
 
 def test_config_parsing_check_auth():
@@ -28,3 +31,12 @@ def test_config_parsing_check_auth():
     parser = main.build_parser()
     args = parser.parse_args('configure display-auth-cache'.split())
     assert args.func == config.display_auth_cache
+
+@patch('coursera_autograder.commands.config.sys.exit')
+def test_config_help_message(exit):
+    testargs = ['placeholder', 'configure']
+    with LogCapture() as logs:
+        with patch.object(sys, 'argv', testargs):
+            parser = main.build_parser()
+
+    config.sys.exit.assert_called_with(1) 


### PR DESCRIPTION
README changed to more accurately inform users about how to get course branch id.
`coursera_autograder configure` command now displays usage message if user does not provide any arguments + unit test added for this behavior